### PR TITLE
Standalone image migration script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ lerna-debug.log*
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
+tmp/*
+!tmp/.keep
+
 # Runtime data
 pids
 *.pid

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # alchemy_contentful_migration
-A Node.js script to migrate europeana Alchemy CMS data into contentful.
-Based on [this gist](https://gist.github.com/andyjmaclean/99d86abddc366f4c3864124a287a59f0).
+A Node.js script to migrate Europeana exhibitions from Alchemy CMS data into
+Contentful.
 
 ## Installing Dependencies
 
-run:
-
-    npm install
+Run:
+```
+npm install
+```
 
 ## Setup
-Set Variable values in .env (copy .env.example) for:
+
+Set variable values in .env (copy .env.example) for:
 
 * imageServer (include trailing back-slash)
 * pgClient
@@ -24,11 +26,24 @@ and the contentful variables:
 * cSpaceId
 * accessToken
 
-## Running the script
+## Running the scripts
 
-comment out the 'clean' commands as per the contentful environment
+### Images
 
-    run node index.js
+To migrate just the images from Alchemy into Contentful as assets, run:
+```
+node images.js
+```
+
+It will maintain a log of the images previously migrated in tmp/images.json and
+so can be stopped and resumed without starting over.
+
+### Entries
+
+Comment out the 'clean' commands as per the contentful environment, and run:
+```
+node index.js
+```
 
 The script generates the file log.txt to record:
 

--- a/images.js
+++ b/images.js
@@ -1,0 +1,87 @@
+require('dotenv').config();
+const contentful = require('contentful-management');
+const { Client } = require('pg');
+const fs = require('fs');
+const imageServer = process.env.alchemyImageServer;
+const locale = 'en-GB';
+
+const imageLog = './tmp/images.json';
+const images = fs.existsSync(imageLog) ? require(imageLog) : {};
+
+const maxLengthShort = 255;
+const maxLengthLong = 2000;
+
+const pgClient = new Client({
+  user: process.env.pgUser,
+  host: process.env.pgHost,
+  database: process.env.pgDatabase,
+  port: process.env.pgPort
+});
+
+let space;
+let environment;
+
+const cEnvironmentId = process.env.cEnvironmentId;
+const cSpaceId = process.env.cSpaceId;
+
+const cClient = contentful.createClient({
+  accessToken: process.env.cAccessToken
+});
+
+const wrapLocale = (val, l, max) => {
+  return {
+    [l ? l : locale]: (typeof val === 'string' && max) ? val.substr(0, max) : val
+  };
+};
+
+const migrateImage = async(picture) => {
+  if (images[picture.image_file_uid]) {
+    console.log(`[EXISTS] ${picture.image_file_uid}: ${images[picture.image_file_uid]}`);
+    return;
+  }
+
+  try {
+    const asset = await environment.createAsset({
+      fields: {
+        title: wrapLocale(picture.title, null, maxLengthShort),
+        file: wrapLocale({
+          contentType: picture.image_file_format ? `image/${picture.image_file_format}` : null,
+          fileName: picture.image_file_uid,
+          upload: `${imageServer}${encodeURIComponent(picture.image_file_uid)}`
+        })
+      }
+    });
+
+    const processedAsset = await asset.processForAllLocales();
+    await processedAsset.publish();
+    images[picture.image_file_uid] = asset.sys.id;
+    fs.writeFileSync(imageLog, JSON.stringify(images, null, 2));
+
+    console.log(`[NEW] ${picture.image_file_uid}: ${asset.sys.id}`);
+  } catch(e) {
+    console.log(`[ERROR] ${picture.image_file_uid}: ${asset.sys.id} / ${e}`);
+  }
+};
+
+const migrateImages = async() => {
+  space = await cClient.getSpace(cSpaceId);
+  environment = await space.getEnvironment(cEnvironmentId);
+
+  await pgClient.connect();
+  const res = await pgClient.query(`
+    SELECT DISTINCT ON (ap.id, ap.image_file_uid, ap.image_file_format) aec.title, ap.image_file_uid, ap.image_file_format
+    FROM alchemy_essence_pictures aep
+    INNER JOIN alchemy_pictures ap ON aep.picture_id=ap.id
+    INNER JOIN alchemy_contents ac ON ac.essence_id=aep.id AND ac.essence_type='Alchemy::EssencePicture'
+    INNER JOIN alchemy_elements ae ON ac.element_id=ae.id
+    INNER JOIN alchemy_contents acc ON acc.element_id=ae.id AND acc.essence_type='Alchemy::EssenceCredit'
+    INNER JOIN alchemy_essence_credits aec ON acc.essence_id=aec.id
+  `);
+  await pgClient.end();
+
+  for (const picture of res.rows) {
+    await migrateImage(picture);
+  }
+};
+
+migrateImages();

--- a/images.js
+++ b/images.js
@@ -61,7 +61,7 @@ const migrateImage = async(picture) => {
 
     console.log(`[NEW] ${uid}: ${asset.sys.id}`);
   } catch(e) {
-    console.log(`[ERROR] ${uid}: ${asset.sys.id} / ${e}`);
+    console.log(`[ERROR] ${uid}: ${e}`);
   }
 };
 


### PR DESCRIPTION
Run with:
```
node images.js
```

It will maintain a log of the images previously migrated in tmp/images.json and so can be stopped and resumed without starting over.

In future, index.js should be adapted to not create images itself but rely on this log file to get the sys ID of any linked assets it needs, making it much faster to run.