### PR TITLE
Use MD5 hash for image asset IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ To migrate just the images from Alchemy into Contentful as assets, run:
 node images.js
 ```
 
-It will maintain a log of the images previously migrated in tmp/images.json and
-so can be stopped and resumed without starting over.
+The sys ID of the asset will be derived from the MD5 hash of the Alchemy picture
+UID, and only be stored if it does not already exist, so can be stopped and
+resumed without starting over.
 
 ### Entries
 

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 
 const cheerio = require('cheerio');
 const fs = require('fs');
-const TurndownService = require('turndown');
-const turndownService = new TurndownService();
 
-const { pgClient, contentfulManagementClient } = require('./src/config');
-const { assetExists, assetIdForImage } = require('./src/assets');
+const {
+  pgClient, contentfulManagementClient, turndownService, defaultLocale
+} = require('./src/config');
+const { assetExists, assetIdForImage, loadAssetIds } = require('./src/assets');
+const { wrapLocale } = require('./src/utils');
 
 const errorLog = fs.createWriteStream('log.txt', {flags: 'w'});
-const locale = 'en-GB';
 
 const maxLengthShort = 255;
 const maxLengthLong = 2000;
@@ -131,7 +131,7 @@ const mimicAsset = (data) => {
 const mimicValidate = (ob, shortTexts, longTexts) => {
   const test = (subject, arr, maxLen) => {
     arr.forEach((f) => {
-      if(subject.fields[f] && subject.fields[f][locale] && subject.fields[f][locale].length > maxLen){
+      if(subject.fields[f] && subject.fields[f][defaultLocale] && subject.fields[f][defaultLocale].length > maxLen){
         throw new Error(`invalid ${f} (length > ${maxLen})`);
       }
     });
@@ -158,14 +158,8 @@ const writeEntry = async (type, entryData) => {
   }
 };
 
-const wrapLocale = (val, l, max) => {
-  return {
-    [l ? l : locale]: (typeof val === 'string' && max) ? val.substr(0, max) : val
-  };
-};
-
 const getObjectBase = () => {
-  return { hasPart: { [locale]: [] } };
+  return { hasPart: { [defaultLocale]: [] } };
 };
 
 const getEntryLink = (id) => {
@@ -342,7 +336,7 @@ const processEmbedRow = async (row, cObject, name) => {
   let htmlSrc = await queryHtml(row.essence_id);
   if(htmlSrc){
     const rt = await writeEntry('embed', { fields: { name: wrapLocale(name), embed: wrapLocale(htmlSrc) } });
-    cObject.hasPart[locale].push(getEntryLink(rt.sys.id));
+    cObject.hasPart[defaultLocale].push(getEntryLink(rt.sys.id));
   }
 };
 
@@ -361,7 +355,7 @@ const processImageRow = async (row, cObject, cache, isIntro, pc) => {
   const assetSysId = await assetIdForImage(picture.image_file_uid);
 
   if(!await assetExists(assetSysId)){
-    let msg = `Missing asset for ${picture.image_file_uid}\n\t${encodeURIComponent(picture.image_file_uid)}`;
+    let msg = `Missing asset for ${picture.image_file_uid}\n  ${encodeURIComponent(picture.image_file_uid)}`;
     console.log(msg);
     err(`Missing asset for: ${picture.image_file_uid}`);
     return;
@@ -369,10 +363,10 @@ const processImageRow = async (row, cObject, cache, isIntro, pc) => {
 
   let imageObject = {
     fields: {
-      name: wrapLocale(credit.title, null, maxLengthShort),
-      creator: wrapLocale(credit.author, null, maxLengthShort),
+      name: wrapLocale(credit.title, { max: maxLengthShort }),
+      creator: wrapLocale(credit.author, { max: maxLengthShort }),
       image: {
-        [locale]: {
+        [defaultLocale]: {
           sys: {
             type: 'Link',
             linkType: 'Asset',
@@ -380,32 +374,32 @@ const processImageRow = async (row, cObject, cache, isIntro, pc) => {
           }
         }
       },
-      provider: wrapLocale(credit.institution, null, maxLengthShort),
+      provider: wrapLocale(credit.institution, { max: maxLengthShort }),
       license: wrapLocale(licenseLookup(credit.license))
     }
   };
 
   if(credit.url && credit.url.length > 0){
-    imageObject.fields.url =  wrapLocale(adjustRecordUrl(credit.url), null, maxLengthShort);
+    imageObject.fields.url =  wrapLocale(adjustRecordUrl(credit.url), { max: maxLengthShort });
   }
 
   imageObject = await writeEntry('imageWithAttribution', imageObject);
 
   if(row.element_name === 'image_compare'){
     if(cache.imageCompare){
-      let icTitle = [cache.imageCompare.fields.name[locale],
-        imageObject.fields.name[locale]].join(' / ');
+      let icTitle = [cache.imageCompare.fields.name[defaultLocale],
+        imageObject.fields.name[defaultLocale]].join(' / ');
 
       let imageCompare = await writeEntry('imageComparison', {
         fields: {
-          name: wrapLocale(icTitle, null, maxLengthShort),
+          name: wrapLocale(icTitle, { max: maxLengthShort }),
           hasPart: wrapLocale([
             getEntryLink(cache.imageCompare.sys.id),
             getEntryLink(imageObject.sys.id)
           ])
         }
       });
-      cObject.hasPart[locale].push(
+      cObject.hasPart[defaultLocale].push(
           getEntryLink(imageCompare.sys.id)
       );
       cache.imageCompare = false;
@@ -416,12 +410,12 @@ const processImageRow = async (row, cObject, cache, isIntro, pc) => {
   }
   else if(!cObject.primaryImageOfPage){
     cObject.primaryImageOfPage = {
-      [locale]: getEntryLink(imageObject.sys.id)
+      [defaultLocale]: getEntryLink(imageObject.sys.id)
     };
   }
   else{
     if(!isIntro){
-      cObject.hasPart[locale].push(getEntryLink(imageObject.sys.id));
+      cObject.hasPart[defaultLocale].push(getEntryLink(imageObject.sys.id));
     }
     else{
       err(`Image will not be saved: ${picture.image_file_uid}`);
@@ -441,12 +435,12 @@ const processTextRow = async (row, cObject, isIntro) => {
 
   if(row.name === 'title'){
     if(!cObject.name){
-      cObject.name = wrapLocale(text, null, maxLengthShort);
+      cObject.name = wrapLocale(text, { max: maxLengthShort });
     }
   }
   else if(row.name === 'sub_title'){
     if(!cObject.headline){
-      cObject.headline = wrapLocale(text, null, maxLengthShort);
+      cObject.headline = wrapLocale(text, { max: maxLengthShort });
     }
   }
   else if(row.name === 'body' && isIntro) {
@@ -458,9 +452,9 @@ const processTextRow = async (row, cObject, isIntro) => {
     }
 
     if (isIntro) {
-      cObject.text = wrapLocale(turndownService.turndown(fieldValue), null, maxLengthLong);
+      cObject.text = wrapLocale(turndownService.turndown(fieldValue), { max: maxLengthLong });
     } else if (!cObject.description) {
-      cObject.description = wrapLocale(turndownService.turndown(fieldValue), null, maxLengthShort);
+      cObject.description = wrapLocale(turndownService.turndown(fieldValue), { max: maxLengthShort });
     }
   }
   else if(cObject.hasPart && !isIntro){
@@ -475,11 +469,11 @@ const processTextRow = async (row, cObject, isIntro) => {
 
     rt = await writeEntry('richText', {
       fields: {
-        headline: wrapLocale(headlineField, null, maxLengthShort),
-        text: wrapLocale(markdownTextField(textField, row.name), null, maxLengthLong)
+        headline: wrapLocale(headlineField, { max: maxLengthShort }),
+        text: wrapLocale(markdownTextField(textField, row.name), { max: maxLengthLong })
       }
     });
-    cObject.hasPart[locale].push(getEntryLink(rt.sys.id));
+    cObject.hasPart[defaultLocale].push(getEntryLink(rt.sys.id));
   }
 };
 
@@ -539,7 +533,7 @@ const processRows = async (rows, locales, intro) => {
     let description = row.meta_description;
 
     if(description && !cObject.description){
-      cObject.description = wrapLocale(description, null, maxLengthLong);
+      cObject.description = wrapLocale(description, { max: maxLengthLong });
     }
 
     if(row.essence_type === 'Alchemy::EssenceHtml'){
@@ -579,7 +573,7 @@ const smartDelete = async (itemId, recurseLevel = 0) =>  new Promise(async resol
     return;
   }
 
-  const pad     = '\t'.repeat(recurseLevel);
+  const pad = '  '.repeat(recurseLevel);
 
   const loc2arr = (loc) => {
     let res = [];
@@ -607,7 +601,7 @@ const smartDelete = async (itemId, recurseLevel = 0) =>  new Promise(async resol
 
   let fNames = Object.keys(entry.fields);
 
-  console.log(`${pad}(delete ${entry.sys.contentType.sys.id})`);
+  console.log(`${pad}- [DELETE] ${entry.sys.contentType.sys.id}: ${entry.sys.id}`);
 
   if(entry.fields.hasPart){
     let hasPartList = loc2arr(entry.fields.hasPart);
@@ -649,6 +643,8 @@ const runAll = async () =>  {
 
   console.log('deleted old in ' + getTimeString(startTime, new Date().getTime()));
 
+  await loadAssetIds();
+
   await pgClient.connect();
   let resArr = await queryExhibitions('en');
   resArr = resArr.rows.map(x => x.parent_id);
@@ -656,7 +652,7 @@ const runAll = async () =>  {
   resArr = resArr.reverse();
 
   // (3)- override the items to process
-  // resArr = [612];
+  // resArr = [1411];
 
   let completeCount = 0;
   let queueLength = resArr.length;
@@ -665,8 +661,8 @@ const runAll = async () =>  {
     await run(nextExhibitionId);
     const pct = parseInt(100 - (resArr.length / queueLength) * 100);
     completeCount ++;
-    console.log(`\n\t\t--> written exhibition ${nextExhibitionId}\t ${pct}%\t(${completeCount} of ${queueLength})`);
-    console.log('\t\t--> running for ' + getTimeString(startTime, new Date().getTime()));
+    console.log(`\n    --> written exhibition ${nextExhibitionId}   ${pct}%  (${completeCount} of ${queueLength})`);
+    console.log('    --> running for ' + getTimeString(startTime, new Date().getTime()));
   }
 
   console.log('done in ' + getTimeString(startTime, new Date().getTime()));
@@ -683,7 +679,7 @@ const run = async(exhibitionId) =>  {
 
     var pDate = new Date(res.rows[0].public_on);
 
-    console.log(`\t...will process ${res.rows.length} rows for ${res.rows[0].urlname.split('/').reverse().pop()}\n\t > ${pDate.toLocaleDateString('en-GB')}\n`);
+    console.log(`  ...will process ${res.rows.length} rows for ${res.rows[0].urlname.split('/').reverse().pop()}\n   > ${pDate.toLocaleDateString('en-GB')}\n`);
 
 
     /* locales / experimental */
@@ -693,18 +689,18 @@ const run = async(exhibitionId) =>  {
 
     if(variants.length > 0){
 
-      console.log(`\tVariant${variants.length == 1 ? '' : 's' } of "${res.rows[0].urlname.split('/').reverse().pop()}":\n`);
+      console.log(`  Variant${variants.length == 1 ? '' : 's' } of "${res.rows[0].urlname.split('/').reverse().pop()}":\n`);
 
       await Promise.all(
         variants.map(async (r) => {
           return new Promise(async resolve => {
             const localeRows = await queryExhibitions(r.language_code, r.exhibition_id);
             locales[r.language_code] = localeRows.rows;
-            resolve(`\t - [${r.language_code}] (${localeRows.rows.length} rows):\t${localeRows.rows[0].title.trim()}`);
+            resolve(`   - [${r.language_code}] (${localeRows.rows.length} rows):  ${localeRows.rows[0].title.trim()}`);
           })
         })
       ).then((debug) => {
-        console.log(`\tVariant${variants.length == 1 ? '' : 's' } of "${res.rows[0].title.trim()}":\n${debug.join('\n')}`);
+        console.log(`  Variant${variants.length == 1 ? '' : 's' } of "${res.rows[0].title.trim()}":\n${debug.join('\n')}`);
       });
     }
     */
@@ -738,7 +734,7 @@ const run = async(exhibitionId) =>  {
         console.log(`Link ${chapterRefs.length} refs...`);
 
         while(chapter = chapterRefs.pop()){
-          intro.fields.hasPart[locale].push(getEntryLink(chapter.sys.id));
+          intro.fields.hasPart[defaultLocale].push(getEntryLink(chapter.sys.id));
         }
         //await intro.update();
         intro = await intro.update();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alchemy-contentful",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -519,7 +519,6 @@
       "version": "7.13.1",
       "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.13.1.tgz",
       "integrity": "sha512-wXKyKYGquLQ/PvFQFDyyrA1C19YxO5HgI5vgeQBEO/IoKNVv0dJp41x6WWXwEVf5Q3/8EfVVmhAMT0OeAJJLcQ==",
-      "dev": true,
       "requires": {
         "axios": "^0.19.1",
         "contentful-resolve-response": "^1.1.4",
@@ -1126,7 +1125,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.1.4.tgz",
       "integrity": "sha512-oFq6n6zjbiwD9/7mBa8YHPwvPM0B0D4uOgg1n/rVzpQPhCrzeIixNj6fbJAbDiJt05rZqxiY3K1Db7pPRhRaZw==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alchemy-contentful",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -13,12 +13,11 @@
   "license": "EUPL-1.2",
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
+    "contentful": "^7.13.1",
     "contentful-cli": "^1.2.5",
     "dotenv": "^8.2.0",
     "pg": "^7.17.1",
     "turndown": "^5.0.3"
   },
-  "devDependencies": {
-    "contentful": "^7.13.1"
-  }
+  "devDependencies": {}
 }

--- a/src/assets.js
+++ b/src/assets.js
@@ -4,9 +4,10 @@ const { contentfulPreviewClient } = require('./config');
 
 let assetIds;
 
-const getAssetIds = async() => {
+// Fetch all asset IDs via the preview API, for later use by `assetExists`
+const loadAssetIds = async() => {
   console.log('Getting asset IDs...');
-  let ids = [];
+  assetIds = [];
 
   let skip = 0;
   let keepGoing = true;
@@ -19,17 +20,17 @@ const getAssetIds = async() => {
     if (assets.items.length === 0) {
       keepGoing = false;
     } else {
-      ids = ids.concat(assets.items.map((item) => item.sys.id));
+      assetIds = assetIds.concat(assets.items.map((item) => item.sys.id));
       skip = skip + 100;
     }
   }
 
   console.log('... done.');
-  return ids;
+  return assetIds;
 };
 
 const assetExists = async(assetId) => {
-  if (!assetIds) assetIds = await getAssetIds();
+  if (!assetIds) await loadAssetIds();
 
   return assetIds.includes(assetId);
 };
@@ -40,5 +41,6 @@ const assetIdForImage = (uid) => {
 
 module.exports = {
   assetExists,
-  assetIdForImage
+  assetIdForImage,
+  loadAssetIds
 };

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,0 +1,20 @@
+const crypto = require('crypto');
+
+const assetExists = async(environment, assetId) => {
+  try {
+    const asset = await environment.getAsset(assetId);
+    return true;
+  } catch (e) {
+    if (e.name === 'NotFound') return false;
+    throw e;
+  }
+};
+
+const assetIdForImage = (uid) => {
+  return crypto.createHash('md5').update(uid).digest('hex');
+};
+
+module.exports = {
+  assetExists,
+  assetIdForImage
+};

--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,7 @@ const TurndownService = require('turndown');
 const turndownService = new TurndownService();
 
 module.exports = {
+  defaultLocale: 'en-GB',
   pgClient,
   contentfulManagementClient,
   contentfulPreviewClient,

--- a/src/credits.js
+++ b/src/credits.js
@@ -1,4 +1,6 @@
-const { imageLog, pgClient, turndownService, contentfulClient } = require('./config');
+const { assetExists, assetIdForImage, loadAssetIds } = require('./assets');
+const { pgClient, turndownService, contentfulManagementClient } = require('./config');
+
 let contentfulConnection;
 
 const pagesSql = `
@@ -79,9 +81,8 @@ const fetchEssence = async(type, id) => {
 };
 
 const contentfulAssetForAlchemyPicture = async(imageFileUid) => {
-  const uid = encodeURIComponent(imageFileUid);
-  const assetId = imageLog[uid];
-  if (!assetId) return '';
+  const assetId = assetIdForImage(imageFileUid);
+  if (!await assetExists(assetId)) return '';
 
   const asset = await contentfulConnection.getAsset(assetId);
 
@@ -148,7 +149,9 @@ const creditExhibition = async(urlname, rows) => {
 };
 
 const run = async() => {
-  contentfulConnection = await contentfulClient.connect();
+  contentfulConnection = await contentfulManagementClient.connect();
+  await loadAssetIds();
+
   await pgClient.connect();
 
   const result = await pgClient.query(pagesSql);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+const { defaultLocale } = require('./config');
+
+const wrapLocale = (value, options = {}) => {
+  const truncated = (typeof value === 'string' && options.max) ? value.slice(0, options.max) : value;
+
+  return {
+    [options.locale || defaultLocale]: truncated
+  };
+};
+
+module.exports = {
+  wrapLocale
+};


### PR DESCRIPTION
Instead of relying on a local log mapping Alchemy picture UIDs to Contentful asset sys IDs:
1. Derive the asset ID from the MD5 hash of the picture UID, and specify it when storing the asset
2. Check for the pre-existence of an asset for a picture knowing its predictable ID

In addition, start refactoring codebase to make it more modular and maintainable.

**NB:** environment variable names have changed.